### PR TITLE
Updates to support CycloneDX XML schema 1.6 SBOMs.

### DIFF
--- a/SbomLicenceCheck.Tests/CycloneDxJsonTests.cs
+++ b/SbomLicenceCheck.Tests/CycloneDxJsonTests.cs
@@ -1,6 +1,3 @@
-using CycloneDX.Models;
-using Moq;
-using SbomLicenceCheck.Common;
 using SbomLicenceCheck.Licences;
 using SbomLicenceCheck.Manifests;
 

--- a/SbomLicenceCheck.Tests/CycloneDxXmlTests.cs
+++ b/SbomLicenceCheck.Tests/CycloneDxXmlTests.cs
@@ -1,6 +1,3 @@
-using CycloneDX.Models;
-using Moq;
-using SbomLicenceCheck.Common;
 using SbomLicenceCheck.Licences;
 using SbomLicenceCheck.Manifests;
 
@@ -18,6 +15,18 @@ namespace SbomLicenceCheck.Tests
 
             Assert.IsTrue(sbomFormat.ComponentLicences.Any());
             Assert.IsTrue(sbomFormat.ComponentLicences["alpine-baselayout"].Any());
+        }
+
+        [Test]
+        public async Task CycloneDXSchema16()
+        {
+            var registry = LicenceRegistry.Load();
+
+            var sbomFormat = new CycloneDxXmlSbom(registry, TestManifests.CycloneDxSchema16Xml);
+            await sbomFormat.Load();
+
+            Assert.IsTrue(sbomFormat.ComponentLicences.Any());
+            Assert.IsTrue(sbomFormat.ComponentLicences["CycloneDX.Core"].Any());
         }
     }
 }

--- a/SbomLicenceCheck.Tests/SbomLicenceCheck.Tests.csproj
+++ b/SbomLicenceCheck.Tests/SbomLicenceCheck.Tests.csproj
@@ -24,10 +24,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SbomLicenceCheck.Tests/SbomLicenceCheck.Tests.csproj
+++ b/SbomLicenceCheck.Tests/SbomLicenceCheck.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,22 +11,27 @@
   <ItemGroup>
     <None Remove="TestManifests\alpine.cyclonedx.xml" />
     <None Remove="TestManifests\pillow.cyclonedx.json" />
+    <None Remove="TestManifests\sbomlicensecheck.cyclonedx.xml" />
     <None Remove="TestManifests\wheel.cyclonedx.json" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="TestManifests\alpine.cyclonedx.xml" />
     <EmbeddedResource Include="TestManifests\pillow.cyclonedx.json" />
+    <EmbeddedResource Include="TestManifests\sbomlicensecheck.cyclonedx.xml" />
     <EmbeddedResource Include="TestManifests\wheel.cyclonedx.json" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SbomLicenceCheck.Tests/TestManifests.cs
+++ b/SbomLicenceCheck.Tests/TestManifests.cs
@@ -1,10 +1,5 @@
 ﻿using SbomLicenceCheck.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SbomLicenceCheck.Tests
 {
@@ -26,6 +21,14 @@ namespace SbomLicenceCheck.Tests
             get
             {
                 return ResourceHelper.ReadResource(Assembly.GetExecutingAssembly(), TestManifests.ManifestsDirectory, "pillow.cyclonedx.json");
+            }
+        }
+
+        public static Stream CycloneDxSchema16Xml
+        {
+            get
+            {
+                return ResourceHelper.ReadResource(Assembly.GetExecutingAssembly(), TestManifests.ManifestsDirectory, "sbomlicensecheck.cyclonedx.xml");
             }
         }
 

--- a/SbomLicenceCheck.Tests/TestManifests/sbomlicensecheck.cyclonedx.xml
+++ b/SbomLicenceCheck.Tests/TestManifests/sbomlicensecheck.cyclonedx.xml
@@ -1,0 +1,966 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" serialNumber="urn:uuid:68e86208-1352-43e7-8f90-3813ff233e48" version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
+  <metadata>
+    <timestamp>2024-11-07T06:18:03.1390683Z</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>CycloneDX module for .NET</name>
+        <version>4.0.0.0</version>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="SbomLicenceCheck@0.0.0">
+      <name>SbomLicenceCheck</name>
+      <version>0.0.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:nuget/Castle.Core@5.1.0">
+      <authors>
+        <author>
+          <name>Castle Project Contributors</name>
+        </author>
+      </authors>
+      <name>Castle.Core</name>
+      <version>5.1.0</version>
+      <description>Castle Core, including DynamicProxy, Logging Abstractions and DictionaryAdapter</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">8577F1ECE48138365EC39BB0236A6E542910CAC2547F88193F37196A01AFC2C7B7A0860BDBA7039E0BD1F72EC8240CD4561FBABDE1FBC91E6EF43F6DA3454E76</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>Copyright (c) 2004-2022 Castle Project - http://www.castleproject.org/</copyright>
+      <purl>pkg:nuget/Castle.Core@5.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.castleproject.org/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/castleproject/Core</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/CommandLineParser@2.9.1">
+      <authors>
+        <author>
+          <name>gsscoder,nemec,ericnewton76,moh-hassan</name>
+        </author>
+      </authors>
+      <name>CommandLineParser</name>
+      <version>2.9.1</version>
+      <description>Terse syntax C# command line parser for .NET.  For FSharp support see CommandLineParser.FSharp.  The Command Line Parser Library offers to CLR applications a clean and concise API for manipulating command line arguments and related tasks.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">4F364E45C9668C7E7CC6A922B488F3FA523033C20D7A432694F0A6AF05CE528EA0481D8375E2F4F1032C6990347B4803CE9A0E48068C6FE15EC46FB1254F085D</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://aka.ms/deprecateLicenseUrl</url>
+        </license>
+      </licenses>
+      <copyright>Copyright (c) 2005 - 2020 Giacomo Stelluti Scala &amp; Contributors</copyright>
+      <purl>pkg:nuget/CommandLineParser@2.9.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/commandlineparser/commandline</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/ConsoleTables@2.6.2">
+      <authors>
+        <author>
+          <name>khalidabuhakmeh</name>
+        </author>
+      </authors>
+      <name>ConsoleTables</name>
+      <version>2.6.2</version>
+      <description>Allows you to print out objects in a table view in a console application. Should be helpful for the diehard console fans.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">6F02E9C0064A498016AB1DCB2889954CE0D0877438AE2E04EE2BD6B09B6B4197BD1A9457F5054A8C752544EC6D3D46850E66BD7FDC843DD673E8A542C57E550A</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>Copyright © Khalid Abuhakmeh 2019</copyright>
+      <purl>pkg:nuget/ConsoleTables@2.6.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/khalidabuhakmeh/ConsoleTables</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/khalidabuhakmeh/ConsoleTables</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/coverlet.collector@6.0.2">
+      <authors>
+        <author>
+          <name>tonerdo</name>
+        </author>
+      </authors>
+      <name>coverlet.collector</name>
+      <version>6.0.2</version>
+      <description>Coverlet is a cross platform code coverage library for .NET, with support for line, branch and method coverage.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">9060EC586906992AA906154D05E8AF0592B145D46B40CFBBFC097236E81FAF48D9EC6A437C5642CC094F7EAFF2642DD036D58F7823C65CDF10E13705E1A3D904</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/coverlet.collector@6.0.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/coverlet-coverage/coverlet</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/coverlet-coverage/coverlet.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/CycloneDX.Core@8.0.2">
+      <authors>
+        <author>
+          <name>Patrick Dwyer &amp; Steve Springett</name>
+        </author>
+      </authors>
+      <name>CycloneDX.Core</name>
+      <version>8.0.2</version>
+      <description>A .NET Standard library for CycloneDX bill-of-material documents.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">8AB6D580957C52DEB8ADBD0AE39642C6804E0756944DF4B8AEB209CE20BE4F00D6481D1C21E188CDE4159CFC8EB5D8E888E529EA24EF3F64AD25A894E2AD0FF2</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>Copyright (c) OWASP Foundation</copyright>
+      <purl>pkg:nuget/CycloneDX.Core@8.0.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/CycloneDX/cyclonedx-dotnet-library</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/CycloneDX/cyclonedx-dotnet-library.git</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/JetBrains.Annotations@2021.2.0">
+      <authors>
+        <author>
+          <name>JetBrains</name>
+        </author>
+      </authors>
+      <name>JetBrains.Annotations</name>
+      <version>2021.2.0</version>
+      <description>Annotations to increase accuracy of ReSharper code inspections</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">E4F1E8A7A6890B2116A2A5B4483346E1BDD0AC7B30D67B5C026B8596C5150A86868BB2D3EACA22D0E22E80DBCFEEEDAE755EC1C29258C8895ACFC3F9710517C5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/JetBrains.Annotations@2021.2.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.jetbrains.com/help/resharper/Code_Analysis__Code_Annotations.html</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Json.More.Net@1.9.0">
+      <authors>
+        <author>
+          <name>Greg Dennis</name>
+        </author>
+      </authors>
+      <name>Json.More.Net</name>
+      <version>1.9.0</version>
+      <description>Provides extended functionality for the System.Text.Json namespace.
+	
+		Read the full documentation at https://docs.json-everything.net/more/json-more/.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">B1EB68F44425F6FA875B92FA59ABC1E6148F520558C86E9F090884019C8524EAC863A96F21D97A589BB613A173C888C58349301B642ACCE3B9A0065B3B42A7ED</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://aka.ms/deprecateLicenseUrl</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Json.More.Net@1.9.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/gregsdennis/json-everything</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/gregsdennis/json-everything</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/JsonPointer.Net@3.0.3">
+      <authors>
+        <author>
+          <name>Greg Dennis</name>
+        </author>
+      </authors>
+      <name>JsonPointer.Net</name>
+      <version>3.0.3</version>
+      <description>[JSON Pointer](https://tools.ietf.org/html/rfc6901) built on the System.Text.Json namespace.
+	
+		Read the full documentation at https://docs.json-everything.net/pointer/basics/.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">D3A88FEBAE2B165BEA48A15BD785D63DB062C5A6D19A5748B2BB882AABC515D9D2362695A75004FEF2419D45DCE887F99A68F9823E36FE57429259171A9857CC</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://aka.ms/deprecateLicenseUrl</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/JsonPointer.Net@3.0.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/gregsdennis/json-everything</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/gregsdennis/json-everything</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/JsonSchema.Net@5.3.1">
+      <authors>
+        <author>
+          <name>Greg Dennis</name>
+        </author>
+      </authors>
+      <name>JsonSchema.Net</name>
+      <version>5.3.1</version>
+      <description>JSON Schema built on the System.Text.Json namespace.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">D95F0B0760055EBB3FEBD86767C8ABBD6719C89A13B4BA5F8E29D8C2E4505B9ADA7C9B939ED6DDFC8150DFA94ACAED03343B6A13857A938FE8162135BC4E16AC</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/JsonSchema.Net@5.3.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/gregsdennis/json-everything</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/gregsdennis/json-everything</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Microsoft.CodeCoverage@17.11.1">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>Microsoft.CodeCoverage</name>
+      <version>17.11.1</version>
+      <description>Microsoft.CodeCoverage package brings infra for collecting code coverage from vstest.console.exe and "dotnet test".</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">649E02875BBB01E988CCDA5CD016CBA32B09D1D26295D22F0326CBDAF0547DBAA1A3CE8DD95AB35FD3C635CF5AF697A667FFF563A00E27B489C62FE90AF2E11C</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.CodeCoverage@17.11.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/microsoft/vstest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/microsoft/vstest</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Microsoft.NET.Test.Sdk@17.11.1">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>Microsoft.NET.Test.Sdk</name>
+      <version>17.11.1</version>
+      <description>The MSbuild targets and properties for building .NET test projects.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">93750BAE9CAB4C72A155E2AA745C225033B0A8A551B554DCCA399F2AA2B0FCDAC81C9E789A44DA1A553901151A9030BCF785F5C13C97B5D9B3CDA0D9A9E96588</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NET.Test.Sdk@17.11.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/microsoft/vstest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/microsoft/vstest</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Microsoft.NETCore.Platforms@1.1.0">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>Microsoft.NETCore.Platforms</name>
+      <version>1.1.0</version>
+      <description>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">6BF892C274596FE2C7164E3D8503B24E187F64D0B7BEC6D9B05EB95F04086FCEB7A85EA6B2685D42DC465C52F6F0E6F636C0B3FDDAC48F6F0125DFD83E92D106</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>http://go.microsoft.com/fwlink/?LinkId=329770</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.NETCore.Platforms@1.1.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Microsoft.TestPlatform.ObjectModel@17.11.1">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>Microsoft.TestPlatform.ObjectModel</name>
+      <version>17.11.1</version>
+      <description>The Microsoft Test Platform Object Model.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">F6127A19B7F721A3F038FDAA81D00360B124F4D5ED02CA79CB7B330688007B4963EF3681594D27F06882571A492FC45AA0F79EE3AAA52417D972ED73F4342000</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.TestPlatform.ObjectModel@17.11.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/microsoft/vstest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/microsoft/vstest</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Microsoft.TestPlatform.TestHost@17.11.1">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>Microsoft.TestPlatform.TestHost</name>
+      <version>17.11.1</version>
+      <description>Testplatform host executes the test using specified adapter.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">75E4476514731D459B0AEDF56A816616DF6A7A53240E6B81B202778E0A90B7C284223D93C7447541EEE70D167761417CE1818808C5CC05DF81001B56470DD6C6</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/Microsoft.TestPlatform.TestHost@17.11.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/microsoft/vstest</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/microsoft/vstest</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Moq@4.18.2">
+      <authors>
+        <author>
+          <name>Daniel Cazzulino, kzu</name>
+        </author>
+      </authors>
+      <name>Moq</name>
+      <version>4.18.2</version>
+      <description>Moq is the most popular and friendly mocking framework for .NET.
+
+Built from https://github.com/moq/moq4/tree/c60833da6</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">F7C8145E759399B13D5DD1B3ACEC8EBDFD898A4923E17A2A6CFA842D3A587D2B03F9BC3623EF952234E3DB6EFD602F3DB7B05196BDF89A2CCACA7EECF487D4C2</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://raw.githubusercontent.com/moq/moq4/main/License.txt</url>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Moq@4.18.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/moq/moq4</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/moq/moq4</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/NETStandard.Library@2.0.0">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>NETStandard.Library</name>
+      <version>2.0.0</version>
+      <description>A set of standard .NET APIs that are prescribed to be used and supported together. 
+d318b764a689cfe285d8484bda918646905664e7 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">E3D64072B9CD9F9E86209C06A22688ECDA7070427C9A35327D2A9560824C0E1381CCF7BC1D21D2EF8B301761F4BFC7F38FBA712DF7188D2F4FE4F748AAC4D0C7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>.NET Foundation and Contributors</copyright>
+      <purl>pkg:nuget/NETStandard.Library@2.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Newtonsoft.Json@13.0.1">
+      <authors>
+        <author>
+          <name>James Newton-King</name>
+        </author>
+      </authors>
+      <name>Newtonsoft.Json</name>
+      <version>13.0.1</version>
+      <description>Json.NET is a popular high-performance JSON framework for .NET</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">83731B662EAF05379A23F8446EF47BBC111349DD4358B7BD8B51383FE9CF637E2FE62F78CEA52A0D7BDD582DC6FBBB5837D4A7B1D53DCF37A0AE7473E21EE7B1</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>Copyright © James Newton-King 2008</copyright>
+      <purl>pkg:nuget/Newtonsoft.Json@13.0.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.newtonsoft.com/json</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/JamesNK/Newtonsoft.Json</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/NUnit@3.13.3">
+      <authors>
+        <author>
+          <name>Charlie Poole, Rob Prouse</name>
+        </author>
+      </authors>
+      <name>NUnit</name>
+      <version>3.13.3</version>
+      <description>NUnit is a unit-testing framework for all .NET languages with a strong TDD focus.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">09DFCA502D636C3123ADF93331732DB354E9E280935D1BBD7923D710F5B29ADF82D41EFC763E2CE8781DDE01D81BBB21AF168D897D5820A53C15A0F9BCF11F20</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://aka.ms/deprecateLicenseUrl</url>
+        </license>
+      </licenses>
+      <copyright>Copyright (c) 2022 Charlie Poole, Rob Prouse</copyright>
+      <purl>pkg:nuget/NUnit@3.13.3</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://nunit.org/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nunit/nunit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/NUnit.Analyzers@3.3.0">
+      <authors>
+        <author>
+          <name>NUnit</name>
+        </author>
+      </authors>
+      <name>NUnit.Analyzers</name>
+      <version>3.3.0</version>
+      <description>Code analyzers and fixes for NUnit 3</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">26C06ED7235878F09F1F77CD7C3FE6A35538D0F0B1A9A0889DE84A7BE757325872583131240487FF6B69A4B97ACA0889366E014937BC0EB0CD802D0FB61A8F4F</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://aka.ms/deprecateLicenseUrl</url>
+        </license>
+      </licenses>
+      <copyright>Copyright (c) 2018-2021 NUnit project</copyright>
+      <purl>pkg:nuget/NUnit.Analyzers@3.3.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/nunit/nunit.analyzers</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nunit/nunit.analyzers</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/NUnit3TestAdapter@4.2.1">
+      <authors>
+        <author>
+          <name>Charlie Poole, Terje Sandstrom</name>
+        </author>
+      </authors>
+      <name>NUnit3TestAdapter</name>
+      <version>4.2.1</version>
+      <description>NUnit3 adapter for running tests in Visual Studio and DotNet. Works with NUnit 3.x, use the NUnit 2 adapter for 2.x tests.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">A6F3745877E32A09D52ED86DCF26F3337AC2B70D4C4F27E4E91958A6F0E69EBF3A2ADA9D444179D377ABAC6CEF48E73658A878A782214C5289C7D3ED59493B3A</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>Copyright (c) 2011-2021 Charlie Poole, 2014-2021 Terje Sandstrom</copyright>
+      <purl>pkg:nuget/NUnit3TestAdapter@4.2.1</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://docs.nunit.org/articles/vs-test-adapter/Index.html</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/nunit/nunit3-vs-adapter</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/protobuf-net@3.2.26">
+      <authors>
+        <author>
+          <name>Marc Gravell</name>
+        </author>
+      </authors>
+      <name>protobuf-net</name>
+      <version>3.2.26</version>
+      <description>Provides simple access to fast and efficient "Protocol Buffers" serialization from .NET applications</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">D69971E1C6E8254A1EF3398CD9F3FE5C57F9026911C6129DD5B390244AA8A549DBED9015ADC5E24A9BA456C139F30B78142B9F636C7F0027F2172288BEF47A62</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>See https://github.com/protobuf-net/protobuf-net</copyright>
+      <purl>pkg:nuget/protobuf-net@3.2.26</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/protobuf-net/protobuf-net</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/protobuf-net/protobuf-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/protobuf-net.Core@3.2.26">
+      <authors>
+        <author>
+          <name>Marc Gravell</name>
+        </author>
+      </authors>
+      <name>protobuf-net.Core</name>
+      <version>3.2.26</version>
+      <description>Provides simple access to fast and efficient "Protocol Buffers" serialization from .NET applications</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">2247E93C92350AC38F352325B684D25B3D3CC1A8489EAC5075B55662A0F6964975D10BF5A26C66F3246A3C0B44125864FC5AE24FC93F83DE670C7ED9609FF8B5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <copyright>See https://github.com/protobuf-net/protobuf-net</copyright>
+      <purl>pkg:nuget/protobuf-net.Core@3.2.26</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/protobuf-net/protobuf-net</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/protobuf-net/protobuf-net</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/System.Collections.Immutable@7.0.0">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>System.Collections.Immutable</name>
+      <version>7.0.0</version>
+      <description>This package provides collections that are thread safe and guaranteed to never change their contents, also known as immutable collections. Like strings, any methods that perform modifications will not change the existing instance but instead return a new instance. For efficiency reasons, the implementation uses a sharing mechanism to ensure that newly created instances share as much data as possible with the previous instance while ensuring that operations have a predictable time complexity.
+
+The System.Collections.Immutable library is built-in as part of the shared framework in .NET Runtime. The package can be installed when you need to use it in other target frameworks.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">F084AFC9395D74B4F252C47B7D0E378E676D6B8B6033A68636B648B58805E3772DD22FF1DED05D3C8C8553D2E7685B29B753FE1CBB5A333F018ABE6422A3EBFA</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Collections.Immutable@7.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dotnet/runtime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/System.Diagnostics.EventLog@6.0.0">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>System.Diagnostics.EventLog</name>
+      <version>6.0.0</version>
+      <description>Provides the System.Diagnostics.EventLog class, which allows the applications to use the windows event log service.
+
+Commonly Used Types:
+System.Diagnostics.EventLog</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">40103D5B7CB2B41C7CAFCA629C112C5526BB773D11367CA62918D8864FBA8DAC2B48151F37671BCF50499D8F8B268489EE1CADE2FB8947CC06E205A1FAC6784C</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Diagnostics.EventLog@6.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dotnet/runtime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/System.Reflection.Metadata@1.6.0">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>System.Reflection.Metadata</name>
+      <version>1.6.0</version>
+      <description>This packages provides a low-level .NET (ECMA-335) metadata reader and writer. It's geared for performance and is the ideal choice for building higher-level libraries that intend to provide their own object model, such as compilers.
+
+Commonly Used Types:
+System.Reflection.Metadata.MetadataReader
+System.Reflection.PortableExecutable.PEReader
+System.Reflection.Metadata.Ecma335.MetadataBuilder
+System.Reflection.PortableExecutable.PEBuilder
+System.Reflection.PortableExecutable.ManagedPEBuilder
+ 
+30ab651fcb4354552bd4891619a0bdd81e0ebdbf 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+      <scope>excluded</scope>
+      <hashes>
+        <hash alg="SHA-512">F5227666EDC6BB1DA78B8A8E86A68E9BD647CAA2EC6A1580C14A4A5E1FE5CFDE3BDAF0D8C23DC210C405A55F83CEB6ADD1A9ADAB149DC065B38CFDDC9B01BA20</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <name>Unknown - See URL</name>
+          <url>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</url>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Reflection.Metadata@1.6.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/System.Runtime.CompilerServices.Unsafe@6.0.0">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>System.Runtime.CompilerServices.Unsafe</name>
+      <version>6.0.0</version>
+      <description>Provides the System.Runtime.CompilerServices.Unsafe class, which provides generic, low-level functionality for manipulating pointers.
+
+Commonly Used Types:
+System.Runtime.CompilerServices.Unsafe</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">D4057301BE4EC4936F24B9CE003B5EC4D99681AB6D9B65D5393DD38D04CDEC37784AAA12C1A8B50AC3767ED878DAE425749490773FEC01E734F93CF1045822B3</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Runtime.CompilerServices.Unsafe@6.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dotnet/runtime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/System.Text.Encodings.Web@6.0.0">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>System.Text.Encodings.Web</name>
+      <version>6.0.0</version>
+      <description>Provides types for encoding and escaping strings for use in JavaScript, HyperText Markup Language (HTML), and uniform resource locators (URL).
+
+Commonly Used Types:
+System.Text.Encodings.Web.HtmlEncoder
+System.Text.Encodings.Web.UrlEncoder
+System.Text.Encodings.Web.JavaScriptEncoder</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">0F26AFEEAA709EA1F05EF87058408DD9DF640C869D7398B2C9C270268DDF21A9208CD7D2BFA1F7FBD8A5CEAB735DD22D470A3689627C9C4FADC0EA5FE76237FA</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Encodings.Web@6.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dotnet/runtime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/System.Text.Json@6.0.2">
+      <authors>
+        <author>
+          <name>Microsoft</name>
+        </author>
+      </authors>
+      <name>System.Text.Json</name>
+      <version>6.0.2</version>
+      <description>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.
+
+Commonly Used Types:
+System.Text.Json.JsonSerializer
+System.Text.Json.JsonDocument
+System.Text.Json.JsonElement
+System.Text.Json.Utf8JsonWriter
+System.Text.Json.Utf8JsonReader</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">F515D1BF6B3CCDABD6B76FD8BB544415D773A920C4FFA24E59F33AB27A108E086FAEAC7170BDEF7035EFE52F2F69DC44102367A2AD70659EF652CD1ADF3AAECB</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+      <purl>pkg:nuget/System.Text.Json@6.0.2</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://dot.net/</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/dotnet/runtime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:nuget/Wcwidth@1.0.0">
+      <authors>
+        <author>
+          <name>Patrik Svensson, Phil Scott</name>
+        </author>
+      </authors>
+      <name>Wcwidth</name>
+      <version>1.0.0</version>
+      <description>A .NET library that calculates the width of Unicode characters.</description>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-512">55B4CCF073C31AEA4E4AED759CEF872650A11FDC6C857B29F4B12DD5B513ABBDE6776A0791C6139E8A725389C36E722DA6FDB32034839F61791CD6F1B86F60F9</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:nuget/Wcwidth@1.0.0</purl>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/spectreconsole/wcwidth</url>
+        </reference>
+        <reference type="vcs">
+          <url>https://github.com/spectreconsole/wcwidth</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="pkg:nuget/Castle.Core@5.1.0">
+      <dependency ref="pkg:nuget/System.Diagnostics.EventLog@6.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/CommandLineParser@2.9.1" />
+    <dependency ref="pkg:nuget/ConsoleTables@2.6.2">
+      <dependency ref="pkg:nuget/Wcwidth@1.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/coverlet.collector@6.0.2" />
+    <dependency ref="pkg:nuget/CycloneDX.Core@8.0.2">
+      <dependency ref="pkg:nuget/JsonSchema.Net@5.3.1" />
+      <dependency ref="pkg:nuget/protobuf-net@3.2.26" />
+    </dependency>
+    <dependency ref="pkg:nuget/JetBrains.Annotations@2021.2.0" />
+    <dependency ref="pkg:nuget/Json.More.Net@1.9.0">
+      <dependency ref="pkg:nuget/System.Text.Json@6.0.2" />
+    </dependency>
+    <dependency ref="pkg:nuget/JsonPointer.Net@3.0.3">
+      <dependency ref="pkg:nuget/Json.More.Net@1.9.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/JsonSchema.Net@5.3.1">
+      <dependency ref="pkg:nuget/JetBrains.Annotations@2021.2.0" />
+      <dependency ref="pkg:nuget/Json.More.Net@1.9.0" />
+      <dependency ref="pkg:nuget/JsonPointer.Net@3.0.3" />
+    </dependency>
+    <dependency ref="pkg:nuget/Microsoft.CodeCoverage@17.11.1" />
+    <dependency ref="pkg:nuget/Microsoft.NET.Test.Sdk@17.11.1">
+      <dependency ref="pkg:nuget/Microsoft.CodeCoverage@17.11.1" />
+      <dependency ref="pkg:nuget/Microsoft.TestPlatform.TestHost@17.11.1" />
+    </dependency>
+    <dependency ref="pkg:nuget/Microsoft.NETCore.Platforms@1.1.0" />
+    <dependency ref="pkg:nuget/Microsoft.TestPlatform.ObjectModel@17.11.1">
+      <dependency ref="pkg:nuget/System.Reflection.Metadata@1.6.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/Microsoft.TestPlatform.TestHost@17.11.1">
+      <dependency ref="pkg:nuget/Microsoft.TestPlatform.ObjectModel@17.11.1" />
+      <dependency ref="pkg:nuget/Newtonsoft.Json@13.0.1" />
+    </dependency>
+    <dependency ref="pkg:nuget/Moq@4.18.2">
+      <dependency ref="pkg:nuget/Castle.Core@5.1.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/NETStandard.Library@2.0.0">
+      <dependency ref="pkg:nuget/Microsoft.NETCore.Platforms@1.1.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/Newtonsoft.Json@13.0.1" />
+    <dependency ref="pkg:nuget/NUnit.Analyzers@3.3.0" />
+    <dependency ref="pkg:nuget/NUnit@3.13.3">
+      <dependency ref="pkg:nuget/NETStandard.Library@2.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/NUnit3TestAdapter@4.2.1" />
+    <dependency ref="pkg:nuget/protobuf-net.Core@3.2.26">
+      <dependency ref="pkg:nuget/System.Collections.Immutable@7.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/protobuf-net@3.2.26">
+      <dependency ref="pkg:nuget/protobuf-net.Core@3.2.26" />
+    </dependency>
+    <dependency ref="pkg:nuget/System.Collections.Immutable@7.0.0" />
+    <dependency ref="pkg:nuget/System.Diagnostics.EventLog@6.0.0" />
+    <dependency ref="pkg:nuget/System.Reflection.Metadata@1.6.0" />
+    <dependency ref="pkg:nuget/System.Runtime.CompilerServices.Unsafe@6.0.0" />
+    <dependency ref="pkg:nuget/System.Text.Encodings.Web@6.0.0">
+      <dependency ref="pkg:nuget/System.Runtime.CompilerServices.Unsafe@6.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/System.Text.Json@6.0.2">
+      <dependency ref="pkg:nuget/System.Runtime.CompilerServices.Unsafe@6.0.0" />
+      <dependency ref="pkg:nuget/System.Text.Encodings.Web@6.0.0" />
+    </dependency>
+    <dependency ref="pkg:nuget/Wcwidth@1.0.0" />
+    <dependency ref="SbomLicenceCheck@0.0.0">
+      <dependency ref="pkg:nuget/CommandLineParser@2.9.1" />
+      <dependency ref="pkg:nuget/ConsoleTables@2.6.2" />
+      <dependency ref="pkg:nuget/CycloneDX.Core@8.0.2" />
+      <dependency ref="pkg:nuget/coverlet.collector@6.0.2" />
+      <dependency ref="pkg:nuget/Microsoft.NET.Test.Sdk@17.11.1" />
+      <dependency ref="pkg:nuget/Moq@4.18.2" />
+      <dependency ref="pkg:nuget/NUnit@3.13.3" />
+      <dependency ref="pkg:nuget/NUnit.Analyzers@3.3.0" />
+      <dependency ref="pkg:nuget/NUnit3TestAdapter@4.2.1" />
+    </dependency>
+  </dependencies>
+</bom>

--- a/SbomLicenceCheck/Manifests/CycloneDxXmlSbom.cs
+++ b/SbomLicenceCheck/Manifests/CycloneDxXmlSbom.cs
@@ -34,11 +34,14 @@ namespace SbomLicenceCheck.Manifests
                     LicencesFound[component.Name] = new List<Licence>();
                 }
 
-                foreach (var licence in component.Licenses)
+                if (component.Licenses != null)
                 {
-                    var Licence = this.registry.Licences.SingleOrDefault(
-                        l => string.Compare(l.LicenceId, licence.License.Id, true, CultureInfo.InvariantCulture) == 0);
-                    LicencesFound[component.Name].Add(Licence ?? Licence.UnknownLicence);
+                    foreach (var licence in component.Licenses)
+                    {
+                        var Licence = this.registry.Licences.SingleOrDefault(
+                            l => string.Compare(l.LicenceId, licence.License.Id, true, CultureInfo.InvariantCulture) == 0);
+                        LicencesFound[component.Name].Add(Licence ?? Licence.UnknownLicence);
+                    }
                 }
             }
 

--- a/SbomLicenceCheck/SbomLicenceCheck.csproj
+++ b/SbomLicenceCheck/SbomLicenceCheck.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<PackageType>DotnetTool</PackageType>
@@ -14,7 +14,7 @@
 	<ToolCommandName>SbomLicenceCheck</ToolCommandName>
 	<PackageLicenceExpression>MIT</PackageLicenceExpression>
 	<NeutralLanguage>en</NeutralLanguage>
-	<AnalysisLevel>6.0-recommended</AnalysisLevel>
+	<AnalysisLevel>latest-recommended</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="ConsoleTables" Version="2.4.2" />
-    <PackageReference Include="CycloneDX.Core" Version="5.3.0" />
+    <PackageReference Include="ConsoleTables" Version="2.6.2" />
+    <PackageReference Include="CycloneDX.Core" Version="8.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request contains fixes for https://github.com/crew-briggs/SbomLicenceCheck/issues/1

* Updated references.
* Added a check for when a component doesn't have any Licenses.
* Added test case and file for testing.